### PR TITLE
cursor update for flutter 2.2

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/test/extended_masked_text_test.dart
+++ b/test/extended_masked_text_test.dart
@@ -80,7 +80,7 @@ void main() {
       expect(controller.text, '1234 **** **** 5678');
     });
 
-    test('check cursor position after edit in specifc possition', () {
+    test('check cursor position after edit in specifc possition', () async {
       final cpfController = MaskedTextController(
         text: '12345678901',
         mask: '000.000.000-00',
@@ -90,7 +90,9 @@ void main() {
       cpfController.selection = TextSelection.fromPosition(
         const TextPosition(offset: 1),
       );
+
       cpfController.text = '19345678901';
+      await Future.delayed(Duration.zero);
       expect(cpfController.selection.baseOffset, 2);
     });
 


### PR DESCRIPTION
Create adjustments for cursor update in Flutter 2.2.

With the text update, the TextEditingController is updating the cursor concurrently, so it is hard to know which call goes first. For now I found that the simplest solution was to add a Future.delayed to ensure that _moveCursor position was the last to be used.

https://github.com/LeandroNovak/extended_masked_text/issues/9#issuecomment-845800283