### PR TITLE
Fixed move cursor to end money_masked_text_controller.dart

### DIFF
--- a/lib/src/money_masked_text_controller.dart
+++ b/lib/src/money_masked_text_controller.dart
@@ -131,7 +131,7 @@ class MoneyMaskedTextController extends TextEditingController {
         CursorBehavior.end => _moveCursorToEnd(),
       };
 
-  void _moveCursorToEnd() => _moveCursor(text.length - leftSymbol.length, true);
+  void _moveCursorToEnd() => _moveCursor(text.length - rightSymbol.length, true);
 
   /// Moves cursor to specific position
   void _moveCursor(int index, [bool force = false]) {


### PR DESCRIPTION
It was setting the cursor before the decimal digits when it was using the leftSymbol, so I noticed that the code was using the wrong symbol to move the cursor to the end, it should use the righSymbol length.